### PR TITLE
Syncdav: support for new options & other changes

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -137,7 +137,7 @@ var App = function App() {
                   }
                   
                   if(data.note) {
-                    contact.bday = data.note;
+                    contact.note = data.note;
                   }
                   
                   if(data.sex) {
@@ -149,7 +149,12 @@ var App = function App() {
                   }
                   
                   if(data.photo) {
+//                    contact.photo = [new Blob([data.photo], {type : 'image/jpeg'})];
                     contact.photo = data.photo;
+                  }
+                  
+                  if(data.adr) {
+                    contact.adr = data.adr;
                   }
                   
                   var saving = navigator.mozContacts.save(contact);

--- a/js/app.js
+++ b/js/app.js
@@ -148,6 +148,10 @@ var App = function App() {
                     contact.genderIdentity = data.gender;
                   }
                   
+                  if(data.photo) {
+                    contact.photo = data.photo;
+                  }
+                  
                   var saving = navigator.mozContacts.save(contact);
                   saving.onsuccess = function() {
                     console.log('New contact saved');

--- a/js/app.js
+++ b/js/app.js
@@ -184,10 +184,9 @@ var App = function App() {
                   }
 
                   if(data.photo) {
-            		    for(i = 0; i < data.photo.length; i++) {
-            		      data.photo[i] = base64DecToArr(data.photo[i]);
-	                  }
-
+            	    for(i = 0; i < data.photo.length; i++) {
+            	      data.photo[i] = base64DecToArr(data.photo[i]);
+	            }
                     contact.photo = [new Blob(data.photo)];
                   }
 

--- a/js/app.js
+++ b/js/app.js
@@ -25,6 +25,41 @@ var App = function App() {
     }
   };
 
+// Helper functions for base64
+  function b64ToUint6 (nChr) {
+    return nChr > 64 && nChr < 91 ?
+        nChr - 65
+      : nChr > 96 && nChr < 123 ?
+        nChr - 71
+      : nChr > 47 && nChr < 58 ?
+        nChr + 4
+      : nChr === 43 ?
+        62
+      : nChr === 47 ?
+        63
+      :
+        0;
+  }
+
+  function base64DecToArr (sBase64, nBlocksSize) {
+    var
+      sB64Enc = sBase64.replace(/[^A-Za-z0-9\+\/]/g, ""), nInLen = sB64Enc.length,
+      nOutLen = nBlocksSize ? Math.ceil((nInLen * 3 + 1 >> 2) / nBlocksSize) * nBlocksSize : nInLen * 3 + 1 >> 2, taBytes = new Uint8Array(nOutLen);
+
+    for (var nMod3, nMod4, nUint24 = 0, nOutIdx = 0, nInIdx = 0; nInIdx < nInLen; nInIdx++) {
+      nMod4 = nInIdx & 3;
+      nUint24 |= b64ToUint6(sB64Enc.charCodeAt(nInIdx)) << 18 - 6 * nMod4;
+      if (nMod4 === 3 || nInLen - nInIdx === 1) {
+        for (nMod3 = 0; nMod3 < 3 && nOutIdx < nOutLen; nMod3++, nOutIdx++) {
+          taBytes[nOutIdx] = nUint24 >>> (16 >>> nMod3 & 24) & 255;
+          }
+          nUint24 = 0;
+        }
+      }
+    return taBytes;
+  }
+// End of helper functions for base64
+
   function handleEvent(evt) {
     var btn = evt.target.id;
 
@@ -83,7 +118,7 @@ var App = function App() {
             
             document.getElementById('syncStatus').style.display = 'block';
             document.getElementById('nbContacts').textContent = contactsList.length;
-            
+
             for (var i = 0; i < contactsList.length; i++) {
               openedDAVConnection.getResource(contactsList[i].href, function(res, e) {
                 var vcard = res.contents;
@@ -147,12 +182,15 @@ var App = function App() {
                   if(data.gender) {
                     contact.genderIdentity = data.gender;
                   }
-                  
+
                   if(data.photo) {
-                    contact.photo = [new Blob([data.photo], {type : 'image/jpeg'})];
-//                    contact.photo = data.photo;
+            		    for(i = 0; i < data.photo.length; i++) {
+            		      data.photo[i] = base64DecToArr(data.photo[i]);
+	                  }
+
+                    contact.photo = [new Blob(data.photo)];
                   }
-                  
+
                   if(data.adr) {
                     contact.adr = data.adr;
                   }

--- a/js/app.js
+++ b/js/app.js
@@ -149,8 +149,8 @@ var App = function App() {
                   }
                   
                   if(data.photo) {
-//                    contact.photo = [new Blob([data.photo], {type : 'image/jpeg'})];
-                    contact.photo = data.photo;
+                    contact.photo = [new Blob([data.photo], {type : 'image/jpeg'})];
+//                    contact.photo = data.photo;
                   }
                   
                   if(data.adr) {

--- a/js/vcard.js
+++ b/js/vcard.js
@@ -219,7 +219,7 @@ var VCard;
         related: true,
         categories: true,
         note: true,
-//	photo: true,
+	photo: true,
     };
 
 })();

--- a/js/vcard.js
+++ b/js/vcard.js
@@ -64,7 +64,11 @@ var VCard;
 	          }
 
 	          if(this.tel) {
-		            validateCompoundWithType('email', this.tel);
+		            validateCompoundWithType('tel', this.tel);
+	          }
+
+	          if(this.adr) {
+		            validateCompoundWithType('adr', this.tel);
 	          }
 
 	          if(! this.uid) {
@@ -190,12 +194,13 @@ var VCard;
         // FIXME: these aren't actually defined anywhere. just very commmon.
         //        maybe there should be more?
         emailType: ["work", "home", "internet"],
+        adrType: ["work", "home", "other"],
         langType: ["work", "home"],
         
     };
 
     VCard.allKeys = [
-        'fn', 'n', 'nickname', 'photo', 'bday', 'anniversary', 'gender',
+        'fn', 'n', 'nickname', 'photo', 'bday', 'anniversary', 'gender', 'adr',
         'tel', 'email', 'impp', 'lang', 'tz', 'geo', 'title', 'role', 'logo',
         'org', 'member', 'related', 'categories', 'note', 'prodid', 'rev',
         'sound', 'uid'
@@ -203,6 +208,7 @@ var VCard;
 
     VCard.multivaluedKeys = {
         email: true,
+	adr: true,
         tel: true,
         geo: true,
         title: true,
@@ -212,7 +218,8 @@ var VCard;
         member: true,
         related: true,
         categories: true,
-        note: true
+        note: true,
+//	photo: true,
     };
 
 })();

--- a/js/vcf.js
+++ b/js/vcf.js
@@ -105,6 +105,11 @@ var VCF;
                         value: value
                     });
 
+                } else if(key == 'PHOTO') { // 6.2.4
+                    setAttr({[new Blob([this.parsePhoto(value)], {type: 'image/jpeg'})]});
+//                    setAttr({value: this.parsePhoto(value)});
+//                    setAttr(this.parsePhoto(value));
+                    
                 } else if(key == 'IMPP') { // 6.4.3
                     // RFC 6350 doesn't define TYPEs for IMPP addresses.
                     // It just seems odd to me to have multiple email addresses and phone numbers,
@@ -144,11 +149,7 @@ var VCF;
                     });
 
                 } else if(key =='ADR'){
-                    setAttr({
-                        type: attrs.TYPE,
-                        pref: attrs.PREF,
-                        value: value
-                    });
+                    setAttr(this.parseAdr(attrs.TYPE, attrs.PREFS, value));
                     //TODO: Handle 'LABEL' field.
                 } else {
                     console.log('WARNING: unhandled key: ', key);
@@ -205,6 +206,37 @@ var VCF;
             }
             return gender;
         },
+
+        /**
+	 *
+	 *
+	 *
+	 **/
+        parsePhoto: function(value) {
+	    var photo = {};
+	    var parts = value.split(';');
+	    var parts = parts[2].split(':');
+	    photo.value = parts[1];
+	    return photo.value;
+	},
+
+          parseAdr: function(type, pref, value) {
+	      var adr = {};
+	      var parts = value.split(';');
+	      adr.type = type;
+	      adr.pref = pref;
+//	      adr.pobox = parts[0];
+//	      adr.ext = parts[1];
+	      adr.streetAddress = parts[2];
+	      adr.locality = parts[3];
+	      adr.region = parts[4];
+	      adr.postalCode = parts[5];
+	      adr.countryName = parts[6];
+
+	      return adr;
+	  },
+
+
 
         /** Date/Time parser.
          * 

--- a/js/vcf.js
+++ b/js/vcf.js
@@ -107,10 +107,9 @@ var VCF;
 
                 } else if(key == 'PHOTO') { // 6.2.4
                     //setAttr(this.parsePhoto(value));
-             		    setAttr(
+                   setAttr(
                       this.parsePhoto(value)
-//                        value
-             		    );
+                   );
                     
                 } else if(key == 'IMPP') { // 6.4.3
                     // RFC 6350 doesn't define TYPEs for IMPP addresses.
@@ -136,12 +135,10 @@ var VCF;
                         setAttr({ name: value });
                     }
 
-                } else if(key == 'ORG') { // 6.6.4
-                    var parts = value.split(';');
-                    setAttr({
-                        'organization-name': parts[0],
-                        'organization-unit': parts[1]
-                    });
+                } else if(key == 'ORG') { // RFC2426 3.5.5
+                  setAttr(
+                   value.split(';')
+                  );
 
                 } else if(key == 'RELATED') { // 6.6.6
                     setAttr({
@@ -210,41 +207,41 @@ var VCF;
         },
 
         /**
-	       *
-       	 *
-       	 *
-       	 **/
+         *
+         *
+         *
+         */
         parsePhoto: function(value) {
           var photos = [];
-	        var parts = value.split(';');
-    	    parts = parts[parts.length-1].split(':');
+          var parts = value.split(';');
+          parts = parts[parts.length-1].split(':');
           parts = parts[parts.length-1];
           for(i = 0; i < parts.length; i++) {
-    	      photos[i] = base64DecToArr(parts[i]);
-    	    }
+            photos[i] = base64DecToArr(parts[i]);
+          }
             return parts;
-      	},
+        },
 
         /** Address parser.
-	       *
-       	 *  based on RFC 2426
-       	 *
-       	 **/
+         *
+         *  based on RFC 2426
+         *
+         */
         parseAdr: function(type, pref, value) {
-	       var adr = {};
-	       var parts = value.split(';');
-    	    adr.type = type;
-    	    adr.pref = pref;
-//   	      adr.pobox = parts[0];
-//	        adr.ext = parts[1];
-	       adr.streetAddress = parts[2];
-    	   adr.locality = parts[3];
-    	   adr.region = parts[4];
-    	   adr.postalCode = parts[5];
-    	   adr.countryName = parts[6];
+         var adr = {};
+         var parts = value.split(';');
+          adr.type = type;
+          adr.pref = pref;
+//           adr.pobox = parts[0];
+//          adr.ext = parts[1];
+         adr.streetAddress = parts[2];
+         adr.locality = parts[3];
+         adr.region = parts[4];
+         adr.postalCode = parts[5];
+         adr.countryName = parts[6];
 
           return adr;
-	      },
+        },
 
 
 

--- a/js/vcf.js
+++ b/js/vcf.js
@@ -106,7 +106,6 @@ var VCF;
                     });
 
                 } else if(key == 'PHOTO') { // 6.2.4
-                    //setAttr(this.parsePhoto(value));
                    setAttr(
                       this.parsePhoto(value)
                    );
@@ -135,7 +134,7 @@ var VCF;
                         setAttr({ name: value });
                     }
 
-                } else if(key == 'ORG') { // RFC2426 3.5.5
+                } else if(key == 'ORG') { // 6.6.4
                   setAttr(
                    value.split(';')
                   );
@@ -206,9 +205,9 @@ var VCF;
             return gender;
         },
 
-        /**
+        /** Photo parser.
          *
-         *
+         * based on RFC 6350 6.2.4
          *
          */
         parsePhoto: function(value) {
@@ -224,16 +223,17 @@ var VCF;
 
         /** Address parser.
          *
-         *  based on RFC 2426
+         *  based on RFC 6350 6.3.1
+	 *  pobox & ext are currently not defined in mozContact
          *
          */
         parseAdr: function(type, pref, value) {
          var adr = {};
          var parts = value.split(';');
-          adr.type = type;
-          adr.pref = pref;
-//           adr.pobox = parts[0];
-//          adr.ext = parts[1];
+         adr.type = type;
+         adr.pref = pref;
+//         adr.pobox = parts[0];
+//         adr.ext = parts[1];
          adr.streetAddress = parts[2];
          adr.locality = parts[3];
          adr.region = parts[4];

--- a/js/vcf.js
+++ b/js/vcf.js
@@ -106,7 +106,7 @@ var VCF;
                     });
 
                 } else if(key == 'PHOTO') { // 6.2.4
-                    setAttr({[new Blob([this.parsePhoto(value)], {type: 'image/jpeg'})]});
+                    setAttr({value: [new Blob([this.parsePhoto(value)], {type: 'image/jpeg'})]});
 //                    setAttr({value: this.parsePhoto(value)});
 //                    setAttr(this.parsePhoto(value));
                     


### PR DESCRIPTION
Added support for address (ADR) and contact photo (PHOTO) according to RFC6350.
Corrected support for organization (ORG) which did not comply with RFC6350.
Added alternate date formats.
Works fine on my carddav instances, to be tested against others.